### PR TITLE
link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Welcome!** This is a documentation repository for Facebook's mapping-related projects on OpenStreetMap. Please refer to sections below for materials covered by this repo.
 
 ## General Info
-- Please check out [Mapwith.ai](Mapwith.ai) to get more information about our **Map With AI** service.
+- Please check out [Mapwith.ai](https://mapwith.ai) to get more information about our **Map With AI** service.
 
 - Visit [this OSM Wiki page](https://wiki.openstreetmap.org/wiki/AI-Assisted_Road_Tracing) to read about our data importing process for projects in Thailand and Indonesia.
 


### PR DESCRIPTION
link used to go to https://github.com/facebookmicrosites/Open-Mapping-At-Facebook/blob/master/Mapwith.ai corrected it to be https://mapwith.ai